### PR TITLE
API improvements

### DIFF
--- a/ItemUpgradeQualityIcons.lua
+++ b/ItemUpgradeQualityIcons.lua
@@ -37,11 +37,6 @@ local categoryDataTab = {
 	[categoryEnum.Awakened] = {minLevel = 493, color = ITEM_LEGENDARY_COLOR, icon = "|A:ui-ej-icon-empoweredraid-large:%d:%d|a ", iconObsolete = "|A:ui-ej-icon-empoweredraid-large:%d:%d|a "}, -- update later maybe, for now this is OLD
 }
 
-local function setIcon(trackID, iconString)
-	if not categoryDataTab[trackID] then return end
-	categoryDataTab[trackID].icon = iconString;
-end
-
 local function getIcon(categoryData, isCurrentSeason, size)
 	local iconString;
 	if isCurrentSeason then


### PR DESCRIPTION
What I've done for now:
- New functions GetIconForTrack and GetIconForLink to retrieve the icon string corresponding to the desired track or item link
- Made a table copy of the enum in the API just to make sure nobody messes with the internal table (idk people might do dumb stuff)
- Removed category data table from the API (nobody needs direct access to it, that's what the new functions are for)

Not entirely sure of the value of having the update functions accessible to other addons but heh, for now they can stay.

For the icon styles stuff, do you want me to set things up for them? Can't promise to do it tonight but I could look into it during the week if needs be.